### PR TITLE
refactor: use Zod object schemas, add no-arg input schema, and clean up SSE transport

### DIFF
--- a/src/oura.ts
+++ b/src/oura.ts
@@ -1,17 +1,17 @@
 import { got, type Got } from 'got';
 import { z } from 'zod';
 
-export const GeneralOuraSchema = {
+export const GeneralOuraSchema = z.object({
   start_date: z.string().datetime().describe('Start date to fetch data'),
   end_date: z
     .string()
     .datetime()
-    .default(new Date().toISOString())
+    .default(() => new Date().toISOString())
     .describe('End date to fetch data'),
   next_token: z.string().optional().describe('Next token to fetch next page'),
-};
+});
 
-type GeneralOuraOptions = z.infer<z.ZodObject<typeof GeneralOuraSchema>>;
+export type GeneralOuraOptions = z.infer<typeof GeneralOuraSchema>;
 
 export class Oura {
   got: Got;

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { version } from '../package.json';
 import { Oura, GeneralOuraSchema } from './oura';
 import { dump } from 'js-yaml';
 import { errorToToolResult } from './utils';
+import { z } from 'zod';
 
 const server = new McpServer(
   {
@@ -30,7 +31,7 @@ const oura = new Oura(process.env.OURA_ACCESS_TOKEN);
 server.tool(
   'get_personal_info',
   'Get personal info from Oura',
-  {},
+  z.object({}),
   async () => {
     try {
       const res = await oura.getPersonalInfo();
@@ -195,8 +196,7 @@ export async function startServer(
 
     const app = Polka();
 
-    app.get('/sse', async (req, res) => {
-      console.log(req);
+    app.get('/sse', async (_req, res) => {
       const transport = new SSEServerTransport('/messages', res);
       transports.set(transport.sessionId, transport);
       res.on('close', () => {
@@ -206,7 +206,11 @@ export async function startServer(
     });
 
     app.post('/messages', async (req, res) => {
-      const sessionId = req.query.sessionId as string;
+      const sessionId = req.query.sessionId as string | undefined;
+      if (!sessionId) {
+        res.status(400).send('Missing sessionId');
+        return;
+      }
       const transport = transports.get(sessionId);
       if (transport) {
         await transport.handlePostMessage(req, res);


### PR DESCRIPTION
This PR refactors the server to align with current @modelcontextprotocol/sdk usage patterns and a cleaner Zod setup.

What changed
- Convert GeneralOuraSchema from a shape object to a proper Zod object
  - Adds a lazy default for end_date via default(() => new Date().toISOString())
  - Exports GeneralOuraOptions using z.infer<typeof GeneralOuraSchema>
- Tools: pass an explicit empty input schema for get_personal_info (z.object({}))
- SSE cleanup: remove noisy request logging and handle missing sessionId with a 400 response
- No behavioral API changes; stricter validation and clearer schema typing only

Rationale
- Using a Zod object improves type inference and validation and matches current MCP examples
- Keeping tool definitions consistent prepares for future SDK updates

Follow-ups (optional)
- Bump dependencies to the latest versions: @modelcontextprotocol/sdk and zod (and @chatmcp/sdk if you keep the REST transport)
- Consider switching tool registration to the object-form API (name/description/inputSchema/execute) for readability, though the current positional API remains supported
- Add additional schema refinements (e.g., start_date <= end_date) for better UX

Testing
- Build with bun build and run via stdio and SSE paths
- Ensure OURA_ACCESS_TOKEN is set and try invoking each tool

If you want, I can also add the dependency version bumps in this PR.