### PR TITLE
refactor: add type safety and reduce duplication across Oura MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # oura-mcp
 
-An MCP server for [ouraring.com](https://ouraring.com/).
+An MCP server for [Oura Ring](https://ouraring.com/) that exposes your health and wellness data as tools for AI assistants.
+
+## Setup
+
+1. Create a personal access token at [cloud.ouraring.com](https://cloud.ouraring.com/personal-access-tokens)
+2. Copy the token
 
 ## Usage
 
-Create an access token on [cloud.ouraring.com](https://cloud.ouraring.com/personal-access-tokens):
+### stdio (default)
 
-1. create a personal access token
-2. copy the token
-
-JSON config for `oura-mcp` as `stdio` server:
+Add to your MCP client config (Claude Desktop, Cursor, etc.):
 
 ```json
 {
@@ -18,28 +20,51 @@ JSON config for `oura-mcp` as `stdio` server:
       "command": "npx",
       "args": ["-y", "oura-mcp"],
       "env": {
-        "oura_ACCESS_TOKEN": "<your-token>"
+        "OURA_ACCESS_TOKEN": "<your-token>"
       }
     }
   }
 }
 ```
 
-Alternatively you can run it as:
+### Streamable HTTP
 
-- sse server: `npx -y oura-mcp --sse`
-- streamable http server: `npx -y oura-mcp --http`
+```bash
+OURA_ACCESS_TOKEN=<your-token> npx -y oura-mcp --http
+```
 
-## Capabilities
+Starts on `http://localhost:3000/mcp` by default. Custom endpoint:
 
-- Get Personal Info
-- Get Daily Activity
-- Get Daily Cardiovascular Age
-- Get Daily Sleep
-- Get Daily SpO2
-- Get Daily Stress
-- Get HeartRate
+```bash
+npx -y oura-mcp --http /custom/path
+```
 
+Port is configurable via `PORT` environment variable.
+
+## Tools
+
+All tools support `response_format` (`json` | `markdown`) and paginated endpoints accept `start_date`, `end_date`, `limit`, and `next_token`.
+
+| Tool | Description |
+|------|-------------|
+| `oura_get_personal_info` | User profile: age, weight, height, biological sex, email |
+| `oura_get_daily_activity` | Activity score, steps, calories, active minutes |
+| `oura_get_daily_cardiovascular_age` | Estimated vascular age |
+| `oura_get_daily_sleep` | Sleep score, contributors (deep, REM, efficiency, etc.) |
+| `oura_get_daily_spo2` | Blood oxygen saturation averages |
+| `oura_get_daily_stress` | Stress/recovery minutes and day summary |
+| `oura_get_heartrate` | Heart rate time-series with BPM summary in markdown mode |
+
+## Development
+
+```bash
+bun install
+bun run src/index.ts                    # stdio mode
+bun run src/index.ts --http             # HTTP mode
+npm run build                           # bundle to dist/
+npm run format                          # biome format
+npx tsc --noEmit                        # type check
+```
 
 ## License
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,42 +5,42 @@
     "": {
       "name": "oura-mcp",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "cac": "^6.7.14",
         "got": "^14.6.6",
         "zod": "4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.3.11",
+        "@biomejs/biome": "2.3.14",
         "@types/bun": "latest",
         "typescript": "^5",
       },
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.3.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.11", "@biomejs/cli-darwin-x64": "2.3.11", "@biomejs/cli-linux-arm64": "2.3.11", "@biomejs/cli-linux-arm64-musl": "2.3.11", "@biomejs/cli-linux-x64": "2.3.11", "@biomejs/cli-linux-x64-musl": "2.3.11", "@biomejs/cli-win32-arm64": "2.3.11", "@biomejs/cli-win32-x64": "2.3.11" }, "bin": { "biome": "bin/biome" } }, "sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ=="],
+    "@biomejs/biome": ["@biomejs/biome@2.3.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.14", "@biomejs/cli-darwin-x64": "2.3.14", "@biomejs/cli-linux-arm64": "2.3.14", "@biomejs/cli-linux-arm64-musl": "2.3.14", "@biomejs/cli-linux-x64": "2.3.14", "@biomejs/cli-linux-x64-musl": "2.3.14", "@biomejs/cli-win32-arm64": "2.3.14", "@biomejs/cli-win32-x64": "2.3.14" }, "bin": { "biome": "bin/biome" } }, "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/uXXkBcPKVQY7rc9Ys2CrlirBJYbpESEDme7RKiBD6MmqR2w3j0+ZZXRIL2xiaNPsIMMNhP1YnA+jRRxoOAFrA=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-fh7nnvbweDPm2xEmFjfmq7zSUiox88plgdHF9OIW4i99WnXrAC3o2P3ag9judoUMv8FCSUnlwJCM1B64nO5Fbg=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-XPSQ+XIPZMLaZ6zveQdwNjbX+QdROEd1zPgMwD47zvHV+tCGB88VH+aynyGxAHdzL+Tm/+DtKST5SECs4iwCLg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.11", "", { "os": "win32", "cpu": "x64" }, "sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.8", "", { "peerDependencies": { "hono": "^4" } }, "sha512-0/g2lIOPzX8f3vzW1ggQgvG5mjtFBDBHFAzI5SFAi2DzSqS9luJwqg9T6O/gKYLi+inS7eNxBeIFkkghIPvrMA=="],
+    "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
     "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg=="],
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
@@ -58,7 +58,7 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "bun-types": ["bun-types@1.2.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-b5ITZMnVdf3m1gMvJHG+gIfeJHiQPJak0f7925Hxu6ZN5VKA8AGy4GZ4lM+Xkn6jtWxg5S3ldWvfmXdvnkp3GQ=="],
 
@@ -114,9 +114,9 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.1", "", {}, "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA=="],
 
-    "express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
-    "express-rate-limit": ["express-rate-limit@7.5.0", "", { "peerDependencies": { "express": "^4.11 || 5 || ^5.0.0-beta.1" } }, "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg=="],
+    "express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -146,7 +146,7 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hono": ["hono@4.11.3", "", {}, "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w=="],
+    "hono": ["hono@4.11.9", "", {}, "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
@@ -157,6 +157,8 @@
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.0.1", "", {}, "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -275,5 +277,17 @@
     "zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "body-parser/qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
+
+    "body-parser/raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "body-parser/raw-body/http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "body-parser/raw-body/http-errors/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
   },
   "type": "module",
   "devDependencies": {
-    "@biomejs/biome": "2.3.11",
+    "@biomejs/biome": "2.3.14",
     "@types/bun": "latest",
     "typescript": "^5"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "cac": "^6.7.14",
     "got": "^14.6.6",
     "zod": "4"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,0 @@
-/** Maximum response size in characters to prevent context bloating */
-export const CHARACTER_LIMIT = 25000;

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,82 +1,15 @@
 import { z } from 'zod';
-
-/** Response format options */
-export enum ResponseFormat {
-  JSON = 'json',
-  MARKDOWN = 'markdown',
-}
-
-/** Personal info data from Oura API */
-export interface PersonalInfo {
-  id?: string;
-  age?: number;
-  weight?: number;
-  height?: number;
-  biological_sex?: string;
-  email?: string;
-}
-
-/** Paginated API response wrapper */
-interface PaginatedResponse<T> {
-  data: T[];
-  next_token?: string;
-}
-
-/** Daily activity record */
-interface DailyActivity {
-  day: string;
-  score?: number;
-  active_calories?: number;
-  total_calories?: number;
-  steps?: number;
-  equivalent_walking_distance?: number;
-  high_activity_time?: number;
-  medium_activity_time?: number;
-  low_activity_time?: number;
-}
-
-/** Cardiovascular age record */
-interface CardiovascularAge {
-  day: string;
-  vascular_age?: number;
-}
-
-/** Sleep contributors */
-interface SleepContributors {
-  deep_sleep?: number;
-  efficiency?: number;
-  latency?: number;
-  rem_sleep?: number;
-  restfulness?: number;
-  timing?: number;
-  total_sleep?: number;
-}
-
-/** Daily sleep record */
-interface DailySleep {
-  day: string;
-  score?: number;
-  contributors?: SleepContributors;
-}
-
-/** Daily SPO2 record */
-interface DailySpo2 {
-  day: string;
-  spo2_percentage?: { average: number };
-}
-
-/** Daily stress record */
-interface DailyStress {
-  day: string;
-  stress_high?: number;
-  recovery_high?: number;
-  day_summary?: string;
-}
-
-/** Heart rate record */
-interface HeartrateRecord {
-  bpm?: number;
-}
+import type {
+  CardiovascularAge,
+  DailyActivity,
+  DailySleep,
+  DailySpo2,
+  DailyStress,
+  HeartrateRecord,
+  PaginatedResponse,
+  PersonalInfo,
+} from './types.ts';
+import { ResponseFormat } from './types.ts';
 
 /** Zod schema for response_format parameter */
 export const responseFormatSchema = z
@@ -85,6 +18,49 @@ export const responseFormatSchema = z
   .describe(
     "Output format: 'json' for structured data or 'markdown' for human-readable summary",
   );
+
+/** Push a formatted field line if value is defined */
+function field(
+  lines: string[],
+  label: string,
+  value: unknown,
+  suffix = '',
+): void {
+  if (value !== undefined) lines.push(`- **${label}**: ${value}${suffix}`);
+}
+
+/** Create a paginated formatter that handles JSON/empty/header/next_token boilerplate */
+function makePaginatedFormatter<T extends { day: string }>(
+  title: string,
+  renderItem: (item: T, lines: string[]) => void,
+): (data: PaginatedResponse<T>, format: ResponseFormat) => string {
+  return (data, format) => {
+    if (format === ResponseFormat.JSON) {
+      return JSON.stringify(data, null, 2);
+    }
+
+    const items = data.data || [];
+    if (items.length === 0) {
+      return `# ${title}\n\nNo ${title.toLowerCase()} data found for the specified date range.`;
+    }
+
+    const lines = [
+      `# ${title}`,
+      '',
+      `Found ${items.length} day(s) of data.`,
+      '',
+    ];
+    for (const item of items) {
+      lines.push(`## ${item.day}`);
+      renderItem(item, lines);
+      lines.push('');
+    }
+    if (data.next_token) {
+      lines.push(`*More data available. Use next_token: ${data.next_token}*`);
+    }
+    return lines.join('\n');
+  };
+}
 
 /** Format personal info data */
 export function formatPersonalInfo(
@@ -95,203 +71,81 @@ export function formatPersonalInfo(
     return JSON.stringify(data, null, 2);
   }
 
-  // Markdown format - concise summary
   const lines = ['# Personal Info', ''];
-  if (data.id) lines.push(`- **ID**: ${data.id}`);
-  if (data.age) lines.push(`- **Age**: ${data.age}`);
-  if (data.weight) lines.push(`- **Weight**: ${data.weight} kg`);
-  if (data.height) lines.push(`- **Height**: ${data.height} cm`);
-  if (data.biological_sex)
-    lines.push(`- **Biological Sex**: ${data.biological_sex}`);
-  if (data.email) lines.push(`- **Email**: ${data.email}`);
+  field(lines, 'ID', data.id);
+  field(lines, 'Age', data.age);
+  field(lines, 'Weight', data.weight, ' kg');
+  field(lines, 'Height', data.height, ' cm');
+  field(lines, 'Biological Sex', data.biological_sex);
+  field(lines, 'Email', data.email);
   return lines.join('\n');
 }
 
 /** Format daily activity data */
-export function formatDailyActivity(
-  data: PaginatedResponse<DailyActivity>,
-  format: ResponseFormat,
-): string {
-  if (format === ResponseFormat.JSON) {
-    return JSON.stringify(data, null, 2);
-  }
-
-  const items = data.data || [];
-  if (items.length === 0) {
-    return '# Daily Activity\n\nNo activity data found for the specified date range.';
-  }
-
-  const lines = [
-    '# Daily Activity',
-    '',
-    `Found ${items.length} day(s) of data.`,
-    '',
-  ];
-  for (const day of items) {
-    lines.push(`## ${day.day}`);
-    if (day.score !== undefined) lines.push(`- **Score**: ${day.score}/100`);
-    if (day.active_calories !== undefined)
-      lines.push(`- **Active Calories**: ${day.active_calories} kcal`);
-    if (day.total_calories !== undefined)
-      lines.push(`- **Total Calories**: ${day.total_calories} kcal`);
+export const formatDailyActivity = makePaginatedFormatter<DailyActivity>(
+  'Daily Activity',
+  (day, lines) => {
+    field(lines, 'Score', day.score, '/100');
+    field(lines, 'Active Calories', day.active_calories, ' kcal');
+    field(lines, 'Total Calories', day.total_calories, ' kcal');
     if (day.steps !== undefined)
       lines.push(`- **Steps**: ${day.steps.toLocaleString()}`);
     if (day.equivalent_walking_distance !== undefined)
       lines.push(
         `- **Distance**: ${(day.equivalent_walking_distance / 1000).toFixed(2)} km`,
       );
-    if (day.high_activity_time !== undefined)
-      lines.push(`- **High Activity**: ${day.high_activity_time} min`);
-    if (day.medium_activity_time !== undefined)
-      lines.push(`- **Medium Activity**: ${day.medium_activity_time} min`);
-    if (day.low_activity_time !== undefined)
-      lines.push(`- **Low Activity**: ${day.low_activity_time} min`);
-    lines.push('');
-  }
-  if (data.next_token) {
-    lines.push(`*More data available. Use next_token: ${data.next_token}*`);
-  }
-  return lines.join('\n');
-}
+    field(lines, 'High Activity', day.high_activity_time, ' min');
+    field(lines, 'Medium Activity', day.medium_activity_time, ' min');
+    field(lines, 'Low Activity', day.low_activity_time, ' min');
+  },
+);
 
 /** Format cardiovascular age data */
-export function formatCardiovascularAge(
-  data: PaginatedResponse<CardiovascularAge>,
-  format: ResponseFormat,
-): string {
-  if (format === ResponseFormat.JSON) {
-    return JSON.stringify(data, null, 2);
-  }
-
-  const items = data.data || [];
-  if (items.length === 0) {
-    return '# Cardiovascular Age\n\nNo cardiovascular age data found for the specified date range.';
-  }
-
-  const lines = [
-    '# Cardiovascular Age',
-    '',
-    `Found ${items.length} day(s) of data.`,
-    '',
-  ];
-  for (const day of items) {
-    lines.push(`## ${day.day}`);
-    if (day.vascular_age !== undefined)
-      lines.push(`- **Vascular Age**: ${day.vascular_age} years`);
-    lines.push('');
-  }
-  return lines.join('\n');
-}
+export const formatCardiovascularAge =
+  makePaginatedFormatter<CardiovascularAge>(
+    'Cardiovascular Age',
+    (day, lines) => {
+      field(lines, 'Vascular Age', day.vascular_age, ' years');
+    },
+  );
 
 /** Format daily sleep data */
-export function formatDailySleep(
-  data: PaginatedResponse<DailySleep>,
-  format: ResponseFormat,
-): string {
-  if (format === ResponseFormat.JSON) {
-    return JSON.stringify(data, null, 2);
-  }
-
-  const items = data.data || [];
-  if (items.length === 0) {
-    return '# Daily Sleep\n\nNo sleep data found for the specified date range.';
-  }
-
-  const lines = [
-    '# Daily Sleep',
-    '',
-    `Found ${items.length} day(s) of data.`,
-    '',
-  ];
-  for (const day of items) {
-    lines.push(`## ${day.day}`);
-    if (day.score !== undefined) lines.push(`- **Score**: ${day.score}/100`);
+export const formatDailySleep = makePaginatedFormatter<DailySleep>(
+  'Daily Sleep',
+  (day, lines) => {
+    field(lines, 'Score', day.score, '/100');
     if (day.contributors) {
       const c = day.contributors;
-      if (c.deep_sleep !== undefined)
-        lines.push(`- **Deep Sleep**: ${c.deep_sleep}/100`);
-      if (c.efficiency !== undefined)
-        lines.push(`- **Efficiency**: ${c.efficiency}/100`);
-      if (c.latency !== undefined)
-        lines.push(`- **Latency**: ${c.latency}/100`);
-      if (c.rem_sleep !== undefined)
-        lines.push(`- **REM Sleep**: ${c.rem_sleep}/100`);
-      if (c.restfulness !== undefined)
-        lines.push(`- **Restfulness**: ${c.restfulness}/100`);
-      if (c.timing !== undefined) lines.push(`- **Timing**: ${c.timing}/100`);
-      if (c.total_sleep !== undefined)
-        lines.push(`- **Total Sleep**: ${c.total_sleep}/100`);
+      field(lines, 'Deep Sleep', c.deep_sleep, '/100');
+      field(lines, 'Efficiency', c.efficiency, '/100');
+      field(lines, 'Latency', c.latency, '/100');
+      field(lines, 'REM Sleep', c.rem_sleep, '/100');
+      field(lines, 'Restfulness', c.restfulness, '/100');
+      field(lines, 'Timing', c.timing, '/100');
+      field(lines, 'Total Sleep', c.total_sleep, '/100');
     }
-    lines.push('');
-  }
-  if (data.next_token) {
-    lines.push(`*More data available. Use next_token: ${data.next_token}*`);
-  }
-  return lines.join('\n');
-}
+  },
+);
 
 /** Format SPO2 data */
-export function formatDailySpo2(
-  data: PaginatedResponse<DailySpo2>,
-  format: ResponseFormat,
-): string {
-  if (format === ResponseFormat.JSON) {
-    return JSON.stringify(data, null, 2);
-  }
-
-  const items = data.data || [];
-  if (items.length === 0) {
-    return '# Daily SPO2\n\nNo SPO2 data found for the specified date range.';
-  }
-
-  const lines = [
-    '# Daily SPO2 (Blood Oxygen)',
-    '',
-    `Found ${items.length} day(s) of data.`,
-    '',
-  ];
-  for (const day of items) {
-    lines.push(`## ${day.day}`);
+export const formatDailySpo2 = makePaginatedFormatter<DailySpo2>(
+  'Daily SPO2',
+  (day, lines) => {
     if (day.spo2_percentage) {
       lines.push(`- **Average SPO2**: ${day.spo2_percentage.average}%`);
     }
-    lines.push('');
-  }
-  return lines.join('\n');
-}
+  },
+);
 
 /** Format daily stress data */
-export function formatDailyStress(
-  data: PaginatedResponse<DailyStress>,
-  format: ResponseFormat,
-): string {
-  if (format === ResponseFormat.JSON) {
-    return JSON.stringify(data, null, 2);
-  }
-
-  const items = data.data || [];
-  if (items.length === 0) {
-    return '# Daily Stress\n\nNo stress data found for the specified date range.';
-  }
-
-  const lines = [
-    '# Daily Stress',
-    '',
-    `Found ${items.length} day(s) of data.`,
-    '',
-  ];
-  for (const day of items) {
-    lines.push(`## ${day.day}`);
-    if (day.stress_high !== undefined)
-      lines.push(`- **High Stress**: ${day.stress_high} min`);
-    if (day.recovery_high !== undefined)
-      lines.push(`- **High Recovery**: ${day.recovery_high} min`);
-    if (day.day_summary !== undefined)
-      lines.push(`- **Summary**: ${day.day_summary}`);
-    lines.push('');
-  }
-  return lines.join('\n');
-}
+export const formatDailyStress = makePaginatedFormatter<DailyStress>(
+  'Daily Stress',
+  (day, lines) => {
+    field(lines, 'High Stress', day.stress_high, ' min');
+    field(lines, 'High Recovery', day.recovery_high, ' min');
+    field(lines, 'Summary', day.day_summary);
+  },
+);
 
 /** Format heartrate data */
 export function formatHeartrate(
@@ -307,7 +161,6 @@ export function formatHeartrate(
     return '# Heart Rate\n\nNo heart rate data found for the specified date range.';
   }
 
-  // For markdown, provide a summary instead of all data points
   const bpms = items
     .map((d) => d.bpm)
     .filter((b): b is number => b !== undefined);

--- a/src/oura.ts
+++ b/src/oura.ts
@@ -1,6 +1,16 @@
 import { type Got, got } from 'got';
 import { z } from 'zod';
-import { responseFormatSchema } from './formatters';
+import { responseFormatSchema } from './formatters.ts';
+import type {
+  CardiovascularAge,
+  DailyActivity,
+  DailySleep,
+  DailySpo2,
+  DailyStress,
+  HeartrateRecord,
+  PaginatedResponse,
+  PersonalInfo,
+} from './types.ts';
 
 // Date format regex for YYYY-MM-DD validation
 const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
@@ -53,8 +63,18 @@ function withDefaults(
   };
 }
 
+const ENDPOINTS = {
+  personalInfo: 'usercollection/personal_info',
+  dailyActivity: 'usercollection/daily_activity',
+  dailyCardiovascularAge: 'usercollection/daily_cardiovascular_age',
+  dailySleep: 'usercollection/daily_sleep',
+  dailySpo2: 'usercollection/daily_spo2',
+  dailyStress: 'usercollection/daily_stress',
+  heartrate: 'usercollection/heartrate',
+} as const;
+
 export class Oura {
-  got: Got;
+  private got: Got;
 
   constructor(apiKey: string) {
     this.got = got.extend({
@@ -65,113 +85,73 @@ export class Oura {
     });
   }
 
-  async getPersonalInfo() {
-    const request = this.got.get('usercollection/personal_info');
-
-    const [res, json] = await Promise.all([request, request.json()]);
-
-    if (!res.ok) {
-      throw new Error(
-        `Failed to get personal info: ${res.statusCode}\n${res.body}`,
-      );
-    }
-
-    return json;
-  }
-
-  async getDailyActivity(searchParams: GeneralOuraOptions) {
-    const request = this.got.get('usercollection/daily_activity', {
-      searchParams: withDefaults(searchParams),
+  private async fetch<T>(
+    endpoint: string,
+    label: string,
+    searchParams?: Record<string, string | number>,
+  ): Promise<T> {
+    const request = this.got.get(endpoint, {
+      ...(searchParams ? { searchParams } : {}),
     });
 
     const [res, json] = await Promise.all([request, request.json()]);
 
     if (!res.ok) {
-      throw new Error(
-        `Failed to get daily activity: ${res.statusCode}\n${res.body}`,
-      );
+      throw new Error(`Failed to get ${label}: ${res.statusCode}\n${res.body}`);
     }
 
-    return json;
+    return json as T;
   }
 
-  async getDailyCardiovascularAge(searchParams: GeneralOuraOptions) {
-    const request = this.got.get('usercollection/daily_cardiovascular_age', {
-      searchParams: withDefaults(searchParams),
-    });
-
-    const [res, json] = await Promise.all([request, request.json()]);
-
-    if (!res.ok) {
-      throw new Error(
-        `Failed to get daily cardiovascular age: ${res.statusCode}\n${res.body}`,
-      );
-    }
-
-    return json;
+  getPersonalInfo() {
+    return this.fetch<PersonalInfo>(ENDPOINTS.personalInfo, 'personal info');
   }
 
-  async getDailySleep(searchParams: GeneralOuraOptions) {
-    const request = this.got.get('usercollection/daily_sleep', {
-      searchParams: withDefaults(searchParams),
-    });
-
-    const [res, json] = await Promise.all([request, request.json()]);
-
-    if (!res.ok) {
-      throw new Error(
-        `Failed to get daily sleep: ${res.statusCode}\n${res.body}`,
-      );
-    }
-
-    return json;
+  getDailyActivity(params: GeneralOuraOptions) {
+    return this.fetch<PaginatedResponse<DailyActivity>>(
+      ENDPOINTS.dailyActivity,
+      'daily activity',
+      withDefaults(params),
+    );
   }
 
-  async getDailySpo2(searchParams: GeneralOuraOptions) {
-    const request = this.got.get('usercollection/daily_spo2', {
-      searchParams: withDefaults(searchParams),
-    });
-
-    const [res, json] = await Promise.all([request, request.json()]);
-
-    if (!res.ok) {
-      throw new Error(
-        `Failed to get daily spo2: ${res.statusCode}\n${res.body}`,
-      );
-    }
-
-    return json;
+  getDailyCardiovascularAge(params: GeneralOuraOptions) {
+    return this.fetch<PaginatedResponse<CardiovascularAge>>(
+      ENDPOINTS.dailyCardiovascularAge,
+      'daily cardiovascular age',
+      withDefaults(params),
+    );
   }
 
-  async getDailyStress(searchParams: GeneralOuraOptions) {
-    const request = this.got.get('usercollection/daily_stress', {
-      searchParams: withDefaults(searchParams),
-    });
-
-    const [res, json] = await Promise.all([request, request.json()]);
-
-    if (!res.ok) {
-      throw new Error(
-        `Failed to get daily stress: ${res.statusCode}\n${res.body}`,
-      );
-    }
-
-    return json;
+  getDailySleep(params: GeneralOuraOptions) {
+    return this.fetch<PaginatedResponse<DailySleep>>(
+      ENDPOINTS.dailySleep,
+      'daily sleep',
+      withDefaults(params),
+    );
   }
 
-  async getHeartrate(searchParams: GeneralOuraOptions) {
-    const request = this.got.get('usercollection/heartrate', {
-      searchParams: withDefaults(searchParams),
-    });
+  getDailySpo2(params: GeneralOuraOptions) {
+    return this.fetch<PaginatedResponse<DailySpo2>>(
+      ENDPOINTS.dailySpo2,
+      'daily spo2',
+      withDefaults(params),
+    );
+  }
 
-    const [res, json] = await Promise.all([request, request.json()]);
+  getDailyStress(params: GeneralOuraOptions) {
+    return this.fetch<PaginatedResponse<DailyStress>>(
+      ENDPOINTS.dailyStress,
+      'daily stress',
+      withDefaults(params),
+    );
+  }
 
-    if (!res.ok) {
-      throw new Error(
-        `Failed to get heartrate: ${res.statusCode}\n${res.body}`,
-      );
-    }
-
-    return json;
+  getHeartrate(params: GeneralOuraOptions) {
+    return this.fetch<PaginatedResponse<HeartrateRecord>>(
+      ENDPOINTS.heartrate,
+      'heartrate',
+      withDefaults(params),
+    );
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ export async function startServer(
       port,
       endpoint: options.endpoint,
     });
+    // Cast needed: @chatmcp/sdk bundles an older MCP SDK with incompatible Transport type
     await server.connect(transport as unknown as Transport);
 
     await transport.startServer();

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,5 +1,4 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { PersonalInfo } from './formatters';
 import {
   formatCardiovascularAge,
   formatDailyActivity,
@@ -8,12 +7,12 @@ import {
   formatDailyStress,
   formatHeartrate,
   formatPersonalInfo,
-  ResponseFormat,
   responseFormatSchema,
-} from './formatters';
-import type { GeneralOuraOptions, Oura } from './oura';
-import { GeneralOuraSchemaShape } from './oura';
-import { errorToToolResult, truncateResponse } from './utils';
+} from './formatters.ts';
+import type { GeneralOuraOptions, Oura } from './oura.ts';
+import { GeneralOuraSchemaShape } from './oura.ts';
+import { ResponseFormat } from './types.ts';
+import { errorToToolResult, truncateResponse } from './utils.ts';
 
 // Standard annotations for read-only Oura data tools
 const readOnlyAnnotations = {
@@ -23,22 +22,19 @@ const readOnlyAnnotations = {
   openWorldHint: true,
 };
 
-type OuraMethod = (params: GeneralOuraOptions) => Promise<unknown>;
-type Formatter = (data: unknown, format: ResponseFormat) => string;
-
-interface ToolDefinition {
+interface TypedTool<T> {
   name: string;
   title: string;
   description: string;
-  method: OuraMethod;
-  formatter: Formatter;
+  method: (params: GeneralOuraOptions) => Promise<T>;
+  formatter: (data: T, format: ResponseFormat) => string;
 }
 
 /**
  * Register a standard Oura data tool with the MCP server.
  * Handles common logic: error handling, formatting, truncation.
  */
-function registerOuraTool(server: McpServer, oura: Oura, tool: ToolDefinition) {
+function registerTool<T>(server: McpServer, tool: TypedTool<T>) {
   server.registerTool(
     tool.name,
     {
@@ -49,7 +45,7 @@ function registerOuraTool(server: McpServer, oura: Oura, tool: ToolDefinition) {
     },
     async (args) => {
       try {
-        const res = await tool.method.call(oura, args);
+        const res = await tool.method(args);
         return {
           content: [
             {
@@ -98,9 +94,7 @@ Use when: User asks about their Oura profile, account info, or personal metrics.
           content: [
             {
               type: 'text',
-              text: truncateResponse(
-                formatPersonalInfo(res as PersonalInfo, format),
-              ),
+              text: truncateResponse(formatPersonalInfo(res, format)),
             },
           ],
         };
@@ -110,12 +104,11 @@ Use when: User asks about their Oura profile, account info, or personal metrics.
     },
   );
 
-  // Standard data tools using factory pattern
-  const tools: ToolDefinition[] = [
-    {
-      name: 'oura_get_daily_activity',
-      title: 'Get daily activity from Oura',
-      description: `Fetch daily activity data from Oura Ring.
+  // Standard data tools using generic typed registration
+  registerTool(server, {
+    name: 'oura_get_daily_activity',
+    title: 'Get daily activity from Oura',
+    description: `Fetch daily activity data from Oura Ring.
 
 Returns activity metrics including:
 - Activity score (0-100) and contributor scores
@@ -131,13 +124,14 @@ Args:
   - response_format ('json' | 'markdown'): Output format (default: 'json')
 
 Use when: User asks about daily activity, steps, calories, movement, or exercise patterns.`,
-      method: oura.getDailyActivity,
-      formatter: formatDailyActivity as Formatter,
-    },
-    {
-      name: 'oura_get_daily_cardiovascular_age',
-      title: 'Get daily cardiovascular age from Oura',
-      description: `Fetch cardiovascular age estimates from Oura Ring.
+    method: (p) => oura.getDailyActivity(p),
+    formatter: formatDailyActivity,
+  });
+
+  registerTool(server, {
+    name: 'oura_get_daily_cardiovascular_age',
+    title: 'Get daily cardiovascular age from Oura',
+    description: `Fetch cardiovascular age estimates from Oura Ring.
 
 Returns vascular health metrics including:
 - Estimated vascular age (in years)
@@ -152,13 +146,14 @@ Args:
   - response_format ('json' | 'markdown'): Output format (default: 'json')
 
 Use when: User asks about heart health, cardiovascular age, or vascular fitness.`,
-      method: oura.getDailyCardiovascularAge,
-      formatter: formatCardiovascularAge as Formatter,
-    },
-    {
-      name: 'oura_get_daily_sleep',
-      title: 'Get daily sleep from Oura',
-      description: `Fetch daily sleep summary data from Oura Ring.
+    method: (p) => oura.getDailyCardiovascularAge(p),
+    formatter: formatCardiovascularAge,
+  });
+
+  registerTool(server, {
+    name: 'oura_get_daily_sleep',
+    title: 'Get daily sleep from Oura',
+    description: `Fetch daily sleep summary data from Oura Ring.
 
 Returns sleep metrics including:
 - Sleep score (0-100) and contributor scores
@@ -175,13 +170,14 @@ Args:
   - response_format ('json' | 'markdown'): Output format (default: 'json')
 
 Use when: User asks about sleep quality, sleep duration, sleep scores, or sleep patterns.`,
-      method: oura.getDailySleep,
-      formatter: formatDailySleep as Formatter,
-    },
-    {
-      name: 'oura_get_daily_spo2',
-      title: 'Get daily SPO2 from Oura',
-      description: `Fetch blood oxygen saturation (SpO2) data from Oura Ring.
+    method: (p) => oura.getDailySleep(p),
+    formatter: formatDailySleep,
+  });
+
+  registerTool(server, {
+    name: 'oura_get_daily_spo2',
+    title: 'Get daily SPO2 from Oura',
+    description: `Fetch blood oxygen saturation (SpO2) data from Oura Ring.
 
 Returns oxygen metrics including:
 - Average SpO2 percentage during sleep
@@ -196,13 +192,14 @@ Args:
   - response_format ('json' | 'markdown'): Output format (default: 'json')
 
 Use when: User asks about blood oxygen, SpO2 levels, or breathing during sleep.`,
-      method: oura.getDailySpo2,
-      formatter: formatDailySpo2 as Formatter,
-    },
-    {
-      name: 'oura_get_daily_stress',
-      title: 'Get daily stress from Oura',
-      description: `Fetch daily stress and recovery data from Oura Ring.
+    method: (p) => oura.getDailySpo2(p),
+    formatter: formatDailySpo2,
+  });
+
+  registerTool(server, {
+    name: 'oura_get_daily_stress',
+    title: 'Get daily stress from Oura',
+    description: `Fetch daily stress and recovery data from Oura Ring.
 
 Returns stress metrics including:
 - High stress time (minutes)
@@ -219,13 +216,14 @@ Args:
   - response_format ('json' | 'markdown'): Output format (default: 'json')
 
 Use when: User asks about stress levels, recovery, or daily stress patterns.`,
-      method: oura.getDailyStress,
-      formatter: formatDailyStress as Formatter,
-    },
-    {
-      name: 'oura_get_heartrate',
-      title: 'Get heartrate from Oura',
-      description: `Fetch heart rate time-series data from Oura Ring.
+    method: (p) => oura.getDailyStress(p),
+    formatter: formatDailyStress,
+  });
+
+  registerTool(server, {
+    name: 'oura_get_heartrate',
+    title: 'Get heartrate from Oura',
+    description: `Fetch heart rate time-series data from Oura Ring.
 
 Returns heart rate readings including:
 - BPM (beats per minute) measurements
@@ -241,13 +239,7 @@ Args:
   - response_format ('json' | 'markdown'): Output format (default: 'json'). Use 'markdown' for summary stats.
 
 Use when: User asks about heart rate, BPM, resting heart rate, or heart rate trends.`,
-      method: oura.getHeartrate,
-      formatter: formatHeartrate as Formatter,
-    },
-  ];
-
-  // Register all standard tools
-  for (const tool of tools) {
-    registerOuraTool(server, oura, tool);
-  }
+    method: (p) => oura.getHeartrate(p),
+    formatter: formatHeartrate,
+  });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,77 @@
+/** Response format options */
+export enum ResponseFormat {
+  JSON = 'json',
+  MARKDOWN = 'markdown',
+}
+
+/** Personal info data from Oura API */
+export interface PersonalInfo {
+  id?: string;
+  age?: number;
+  weight?: number;
+  height?: number;
+  biological_sex?: string;
+  email?: string;
+}
+
+/** Paginated API response wrapper */
+export interface PaginatedResponse<T> {
+  data: T[];
+  next_token?: string;
+}
+
+/** Daily activity record */
+export interface DailyActivity {
+  day: string;
+  score?: number;
+  active_calories?: number;
+  total_calories?: number;
+  steps?: number;
+  equivalent_walking_distance?: number;
+  high_activity_time?: number;
+  medium_activity_time?: number;
+  low_activity_time?: number;
+}
+
+/** Cardiovascular age record */
+export interface CardiovascularAge {
+  day: string;
+  vascular_age?: number;
+}
+
+/** Sleep contributors */
+export interface SleepContributors {
+  deep_sleep?: number;
+  efficiency?: number;
+  latency?: number;
+  rem_sleep?: number;
+  restfulness?: number;
+  timing?: number;
+  total_sleep?: number;
+}
+
+/** Daily sleep record */
+export interface DailySleep {
+  day: string;
+  score?: number;
+  contributors?: SleepContributors;
+}
+
+/** Daily SPO2 record */
+export interface DailySpo2 {
+  day: string;
+  spo2_percentage?: { average: number };
+}
+
+/** Daily stress record */
+export interface DailyStress {
+  day: string;
+  stress_high?: number;
+  recovery_high?: number;
+  day_summary?: string;
+}
+
+/** Heart rate record */
+export interface HeartrateRecord {
+  bpm?: number;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { CHARACTER_LIMIT } from './constants';
+/** Maximum response size in characters to prevent context bloating */
+const CHARACTER_LIMIT = 25000;
 
 /**
  * Format an error into an actionable, user-friendly message.


### PR DESCRIPTION
## What

Refactors the Oura MCP server codebase for full type safety and significant code deduplication, reducing total LOC by ~25% while eliminating all type assertions in tool registration.

## Why

- The `Oura` class had 7 nearly identical copy-pasted methods all returning `Promise<unknown>`
- Formatters repeated identical boilerplate (JSON check, empty check, header, next_token pagination)
- Tool registration required `as Formatter` casts because method/formatter types weren't linked
- Types were scattered in `formatters.ts` instead of centralized
- `constants.ts` existed for a single constant used in one file

## How

- Introduced a generic `private fetch<T>()` method in the Oura class, replacing 7 duplicate implementations with typed 3-line wrappers
- Created `makePaginatedFormatter<T>()` higher-order function to extract shared formatting boilerplate, plus a `field()` helper for guarded field rendering
- Added `TypedTool<T>` generic interface and `registerTool<T>()` function that links API method return types to their formatters at compile time — zero `as` casts needed
- Centralized all data interfaces into `src/types.ts`

## Changes

- **Create `src/types.ts`**: Centralized `ResponseFormat` enum, `PersonalInfo`, `PaginatedResponse<T>`, and all data interfaces
- **Rewrite `src/oura.ts`**: Generic `fetch<T>()`, private `got` field, `ENDPOINTS` constant map, typed return values
- **Rewrite `src/formatters.ts`**: `makePaginatedFormatter<T>()`, `field()` helper, standalone `formatHeartrate`/`formatPersonalInfo`
- **Rewrite `src/tools.ts`**: `TypedTool<T>` interface, `registerTool<T>()`, arrow function method binding
- **Update `src/utils.ts`**: Inline `CHARACTER_LIMIT` constant
- **Delete `src/constants.ts`**: No longer needed
- **Update `src/server.ts`**: Add explanatory comment for `as unknown as Transport` cast
- **Update dependencies**: Biome 2.3.14, MCP SDK 1.26.0